### PR TITLE
Secret service

### DIFF
--- a/Nickvision.Aura.Tests/KeyringTest.cs
+++ b/Nickvision.Aura.Tests/KeyringTest.cs
@@ -1,3 +1,4 @@
+using System.Threading.Tasks;
 using Xunit.Abstractions;
 
 namespace Nickvision.Aura.Tests;
@@ -12,15 +13,22 @@ public class KeyringTest
     }
     
     [SkippableFact]
-    public void AccessTest()
+    public async Task AccessTest()
     {
-        var keyring = Keyring.Keyring.Access("org.nickvision.aura.test");
-        // We want the test to succeed when running locally but skip on GitHub where libsecret keyring is locked
+        var keyring = await Keyring.Keyring.AccessAsync("org.nickvision.aura.test");
+        // We want the test to succeed when running locally but skip on GitHub where system keyring is locked
         Skip.If(keyring == null);
-        keyring.Destroy();
-        keyring.Dispose();
+        await keyring.DestroyAsync();
     }
-    
+
+    [Fact]
+    public async Task AccessWithPasswordTest()
+    {
+        var keyring = await Keyring.Keyring.AccessAsync("org.nickvision.aura.test", "TEST");
+        Assert.True(keyring != null);
+        await keyring.DestroyAsync();
+    }
+
     [Theory]
     [InlineData(4)]
     [InlineData(16)]

--- a/Nickvision.Aura/Keyring/Keyring.cs
+++ b/Nickvision.Aura/Keyring/Keyring.cs
@@ -1,4 +1,3 @@
-
 using System;
 using System.Collections.Generic;
 using System.IO;

--- a/Nickvision.Aura/Keyring/KeyringDialogController.cs
+++ b/Nickvision.Aura/Keyring/KeyringDialogController.cs
@@ -62,11 +62,11 @@ public class KeyringDialogController
     /// Enables the Keyring
     /// </summary>
     /// <returns>True if successful, false is Keyring already enabled or error</returns>
-    public bool EnableKeyring(string? password = null)
+    public async Task<bool> EnableKeyringAsync(string? password = null)
     {
         if(Keyring == null)
         {
-            Keyring = Keyring.Access(_keyringName, password);
+            Keyring = await Keyring.AccessAsync(_keyringName, password);
             return Keyring != null;
         }
         return false;
@@ -76,11 +76,11 @@ public class KeyringDialogController
     /// Disables the Keyring and destroys its data
     /// </summary>
     /// <returns>True if successful, false if Keyring already disabled</returns>
-    public bool DisableKeyring()
+    public async Task<bool> DisableKeyringAsync()
     {
         if(Keyring != null)
         {
-            Keyring.Destroy();
+            await Keyring.DestroyAsync();
             Keyring = null;
             return true;
         }
@@ -92,11 +92,11 @@ public class KeyringDialogController
     /// </summary>
     /// <returns>True if successful, false if Keyring doesn't exist or is unlocked</returns>
     /// <remarks>Can only be used if the Keyring is not unlocked. If unlocked, use DisableKeyring()</remarks>
-    public bool ResetKeyring()
+    public async Task<bool> ResetKeyringAsync()
     {
         if (Keyring == null)
         {
-            return Keyring.Destroy(_keyringName);
+            return await Keyring.DestroyAsync(_keyringName);
         }
         return false;
     }

--- a/Nickvision.Aura/Keyring/Store.cs
+++ b/Nickvision.Aura/Keyring/Store.cs
@@ -120,7 +120,7 @@ internal class Store : IDisposable
                 Mode = SqliteOpenMode.ReadWrite,
                 Pooling = false,
                 Password = password
-            }.ConnectionString));            
+            }.ConnectionString));
         }
         catch
         {

--- a/Nickvision.Aura/Keyring/SystemCredentialManager.cs
+++ b/Nickvision.Aura/Keyring/SystemCredentialManager.cs
@@ -1,36 +1,28 @@
+using DBus.Services.Secrets;
 using Meziantou.Framework.Win32;
 using System;
+using System.Collections.Generic;
 using System.Runtime.InteropServices;
+using System.Text;
+using System.Threading.Tasks;
 
 namespace Nickvision.Aura.Keyring;
 
 /// <summary>
 /// Object to access system credential manager
 /// </summary>
-/// <remarks>Uses Windows Credential Manager on Windows and LibSecret on Linux</remarks>
-internal static partial class SystemCredentialManager
+/// <remarks>Uses Windows Credential Manager on Windows and DBus Secret Service on Linux</remarks>
+internal static class SystemCredentialManager
 {
-    [LibraryImport("libsecret-1.so.0", StringMarshalling = StringMarshalling.Utf8)]
-    private static partial nint secret_schema_new(string name, int flags, nint args);
-    [LibraryImport("libsecret-1.so.0", StringMarshalling = StringMarshalling.Utf8)]
-    private static partial string secret_password_lookup_sync(nint schema, nint cancellable, nint error, nint args);
-    [LibraryImport("libsecret-1.so.0", StringMarshalling = StringMarshalling.Utf8)]
-    [return:MarshalAs(UnmanagedType.I1)]
-    private static partial bool secret_password_store_sync(nint schema, nint collection, string label, string password, nint cancellable, nint error, nint args);
-    [LibraryImport("libsecret-1.so.0", StringMarshalling = StringMarshalling.Utf8)]
-    [return:MarshalAs(UnmanagedType.I1)]
-    private static partial bool secret_password_clear_sync(nint schema, nint cancellable, nint error, nint args);
-    [LibraryImport("libsecret-1.so.0")]
-    private static partial void secret_schema_unref(nint schema);
-
-    private const int SECRET_SCHEMA_NONE = 0;
+    private static SecretService? _service;
+    private static Collection? _collection;
 
     /// <summary>
     /// Gets keyring's password from credential manager
     /// </summary>
     /// <param name="name">Keyring name</param>
     /// <returns>Keyring password or null if failed to get password</returns>
-    public static string? GetPassword(string name)
+    public static async Task<string?> GetPasswordAsync(string name)
     {
         if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
         {
@@ -38,10 +30,23 @@ internal static partial class SystemCredentialManager
         }
         if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
         {
-            var schema = secret_schema_new(name, SECRET_SCHEMA_NONE, IntPtr.Zero);
-            var password = secret_password_lookup_sync(schema, IntPtr.Zero, IntPtr.Zero, IntPtr.Zero);
-            secret_schema_unref(schema);
-            return password;
+            if (_service == null)
+            {
+                _service = await SecretService.ConnectAsync(EncryptionType.Dh);
+                _collection = await _service.GetDefaultCollectionAsync() ?? await _service.CreateCollectionAsync("Default keyring", "default");
+            }
+            if (_collection == null)
+            {
+                throw new AuraException("[AURA] Failed to get or create default collection in system keyring.");
+            }
+            await _collection.UnlockAsync();
+            var lookupAttributes = new Dictionary<string, string> {{ "application", name.ToLower() }};
+            var items = await _collection.SearchItemsAsync(lookupAttributes);
+            if (items.Length > 0)
+            {
+                return Encoding.UTF8.GetString(await items[0].GetSecretAsync());
+            }
+            return null;
         }
         throw new PlatformNotSupportedException();
     }
@@ -51,7 +56,7 @@ internal static partial class SystemCredentialManager
     /// </summary>
     /// <param name="name">Keyring name</param>
     /// <returns>Keyring password or null if failed to set password</returns>
-    public static string? SetPassword(string name)
+    public static async Task<string?> SetPasswordAsync(string name)
     {
         var password = new PasswordGenerator().Next();
         if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
@@ -61,13 +66,24 @@ internal static partial class SystemCredentialManager
         }
         if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
         {
-            var schema = secret_schema_new(name, SECRET_SCHEMA_NONE, IntPtr.Zero);
-            var success = secret_password_store_sync(schema, IntPtr.Zero, name, password, IntPtr.Zero, IntPtr.Zero, IntPtr.Zero);
-            secret_schema_unref(schema);
-            if (!success)
+            if (_service == null)
             {
-                return null;
+                _service = await SecretService.ConnectAsync(EncryptionType.Dh);
+                _collection = await _service.GetDefaultCollectionAsync() ?? await _service.CreateCollectionAsync("Default keyring", "default");
             }
+            if (_collection == null)
+            {
+                throw new AuraException("[AURA] Failed to get or create default collection in system keyring.");
+            }
+            await _collection.UnlockAsync();
+            var lookupAttributes = new Dictionary<string, string> {{ "application", name.ToLower() }};
+            var items = await _collection.SearchItemsAsync(lookupAttributes);
+            if (items.Length > 0)
+            {
+                await items[0].SetSecret(Encoding.UTF8.GetBytes(password), "text/plain; charset=utf8");
+                return password;
+            }
+            await _collection.CreateItemAsync(name, lookupAttributes, Encoding.UTF8.GetBytes(password), "text/plain; charset=utf8", false);
             return password;
         }
         throw new PlatformNotSupportedException();
@@ -77,7 +93,7 @@ internal static partial class SystemCredentialManager
     /// Deletes keyring's password from credential manager
     /// </summary>
     /// <param name="name">Keyring name</param>
-    public static void DeletePassword(string name)
+    public static async Task DeletePasswordAsync(string name)
     {
         if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
         {
@@ -86,9 +102,22 @@ internal static partial class SystemCredentialManager
         }
         if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
         {
-            var schema = secret_schema_new(name, SECRET_SCHEMA_NONE, IntPtr.Zero);
-            secret_password_clear_sync(schema, IntPtr.Zero, IntPtr.Zero, IntPtr.Zero);
-            secret_schema_unref(schema);
+            if (_service == null)
+            {
+                _service = await SecretService.ConnectAsync(EncryptionType.Dh);
+                _collection = await _service.GetDefaultCollectionAsync() ?? await _service.CreateCollectionAsync("Default keyring", "default");
+            }
+            if (_collection == null)
+            {
+                throw new AuraException("[AURA] Failed to get or create default collection in system keyring.");
+            }
+            await _collection.UnlockAsync();
+            var lookupAttributes = new Dictionary<string, string> {{ "application", name.ToLower() }};
+            var items = await _collection.SearchItemsAsync(lookupAttributes);
+            if (items.Length > 0)
+            {
+                //await items[0].SetSecret(Array.Empty<byte>(), "text/plain; charset=utf8");
+            }
             return;
         }
         throw new PlatformNotSupportedException();

--- a/Nickvision.Aura/Keyring/SystemCredentialManager.cs
+++ b/Nickvision.Aura/Keyring/SystemCredentialManager.cs
@@ -91,7 +91,13 @@ internal static class SystemCredentialManager
         throw new PlatformNotSupportedException();
     }
 
-    private static async Task<Item[]> GetDBusKeyringItems(string name)
+    /// <summary>
+    /// Gets items from DBus Secret Service Keyring
+    /// </summary>
+    /// <param name="attribute">Attribute value to search for</param>
+    /// <returns>Items Array</returns>
+    /// <remarks>It is possible for multiple items with the same attribute to exist</remarks>
+    private static async Task<Item[]> GetDBusKeyringItems(string attribute)
     {
         if (_service == null)
         {
@@ -103,7 +109,7 @@ internal static class SystemCredentialManager
             throw new AuraException("Failed to get or create default collection in system keyring.");
         }
         await _collection.UnlockAsync();
-        var lookupAttributes = new Dictionary<string, string> {{ "application", name.ToLower() }};
+        var lookupAttributes = new Dictionary<string, string> {{ "application", attribute.ToLower() }};
         return await _collection.SearchItemsAsync(lookupAttributes);
     }
 }

--- a/Nickvision.Aura/Keyring/SystemCredentialManager.cs
+++ b/Nickvision.Aura/Keyring/SystemCredentialManager.cs
@@ -30,7 +30,7 @@ internal static class SystemCredentialManager
         }
         if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
         {
-            var items = await GetDBusKeyringItems(name);
+            var items = await GetDBusKeyringItemsAsync(name);
             if (items.Length > 0)
             {
                 return Encoding.UTF8.GetString(await items[0].GetSecretAsync());
@@ -55,7 +55,7 @@ internal static class SystemCredentialManager
         }
         if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
         {
-            var items = await GetDBusKeyringItems(name);
+            var items = await GetDBusKeyringItemsAsync(name);
             if (items.Length > 0)
             {
                 await items[0].SetSecret(Encoding.UTF8.GetBytes(password), "text/plain; charset=utf8");
@@ -81,7 +81,7 @@ internal static class SystemCredentialManager
         }
         if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
         {
-            var items = await GetDBusKeyringItems(name);
+            var items = await GetDBusKeyringItemsAsync(name);
             if (items.Length > 0)
             {
                 await items[0].SetSecret(Array.Empty<byte>(), "text/plain; charset=utf8");
@@ -97,7 +97,7 @@ internal static class SystemCredentialManager
     /// <param name="attribute">Attribute value to search for</param>
     /// <returns>Items Array</returns>
     /// <remarks>It is possible for multiple items with the same attribute to exist</remarks>
-    private static async Task<Item[]> GetDBusKeyringItems(string attribute)
+    private static async Task<Item[]> GetDBusKeyringItemsAsync(string attribute)
     {
         if (_service == null)
         {

--- a/Nickvision.Aura/Nickvision.Aura.csproj
+++ b/Nickvision.Aura/Nickvision.Aura.csproj
@@ -3,7 +3,6 @@
   <PropertyGroup>
     <TargetFramework>net7.0</TargetFramework>
     <Nullable>enable</Nullable>
-    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <PackageId>Nickvision.Aura</PackageId>
     <Version>2023.9.2</Version>
     <Company>Nickvision</Company>
@@ -20,6 +19,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Ace4896.DBus.Services.Secrets" Version="1.1.0" />
     <PackageReference Include="Markdig" Version="0.31.0" />
     <PackageReference Include="Meziantou.Framework.Win32.CredentialManager" Version="1.4.2" />
     <PackageReference Include="Tmds.DBus" Version="0.15.0" />

--- a/Nickvision.Aura/Nickvision.Aura.csproj
+++ b/Nickvision.Aura/Nickvision.Aura.csproj
@@ -4,7 +4,7 @@
     <TargetFramework>net7.0</TargetFramework>
     <Nullable>enable</Nullable>
     <PackageId>Nickvision.Aura</PackageId>
-    <Version>2023.9.2</Version>
+    <Version>2023.9.3</Version>
     <Company>Nickvision</Company>
     <Authors>Nickvision</Authors>
     <Description>A cross-platform base for Nickvision applications</Description>
@@ -13,9 +13,11 @@
     <Copyright>(c) Nickvision 2021-2023</Copyright>
     <PackageProjectUrl>https://nickvision.org</PackageProjectUrl>
     <RepositoryUrl>https://github.com/NickvisionApps/Aura</RepositoryUrl>
-    <PackageReleaseNotes>- Allow Keyring to use system secrets for password
-    - AppInfo's ShortName and Description are now optional</PackageReleaseNotes>
+    <PackageReleaseNotes>- Some Keyring methods are now async
+    - Keyring doesn't need libsecret on Linux anymore
+    </PackageReleaseNotes>
     <PackageIcon>logo-r.png</PackageIcon>
+    <PackageReadmeFile>README.md</PackageReadmeFile>
   </PropertyGroup>
 
   <ItemGroup>
@@ -28,7 +30,8 @@
   </ItemGroup>
 
   <ItemGroup>
-      <None Include="Resources\logo-r.png" Pack="true" PackagePath="\" />
+    <None Include="Resources\logo-r.png" Pack="true" PackagePath="\" />
+    <None Include="README.md" Pack="true" PackagePath="\"/>
   </ItemGroup>
     
 </Project>

--- a/Nickvision.Aura/README.md
+++ b/Nickvision.Aura/README.md
@@ -1,0 +1,8 @@
+ **A cross-platform base for Nickvision applications**
+
+ Aura provides the following functionality:
+ 1. Stores application information: name, version, changelog etc
+ 2. Allows to load and save configuration files in JSON format
+ 3. Can start an IPC server using named pipe. In this case, an application becomes single-instance. New instances will send command-line arguments to existing one and quit.
+ 4. Access system's network status and listen for changes
+ 5. Store credentials in a secure fashion


### PR DESCRIPTION
Closes #20
Closes #22

Uses [Ace4896.DBus.Services.Secrets](https://github.com/Ace4896/DBus.Services.Secrets) instead of libsecret.
Unfortunately there are some bugs in this package, as workaround an item attribute (`application` with app ID as the value) is used to determine which item in keyring contains the password we need. Not a big deal really, but I find it less straightforward than using item label.
One more ~~unusual~~ (not really unusual: I noticed I have the same thing with items created by other apps) thing is that the data seems to be saved to keyring in some odd way that a password itself isn't shows in an entry in Seahorse. But I tried to print it out and so I'm totally sure a password is saved correctly, it's not empty. Reading a password that was manually typed in Seahorse also works, so it's still possible to migrate a Parabolic's keyring.

Parabolic unsandboxed was successfully tested, will test Flatpak and Snap later.